### PR TITLE
Check DB key size

### DIFF
--- a/src/krakendb.cpp
+++ b/src/krakendb.cpp
@@ -66,6 +66,8 @@ KrakenDB::KrakenDB(char *ptr) {
     errx(EX_DATAERR, "can only handle 4 byte DB values");
   k = key_bits / 2;
   key_len = key_bits / 8 + !! (key_bits % 8);
+  if (key_len != 8)
+    errx(EX_DATAERR, "can only handle 8 byte DB keys");
 }
 
 // Creates an index, indicating starting positions of each bin


### PR DESCRIPTION
In your code you assume that a k-mer is always encoded as a 64 bits integer.
I think it is problematic if the user tries to use a k-mer database with k < 16