### PR TITLE
Remove _1 and _2, or .1 and .2 from read IDs in read_merger.pl

### DIFF
--- a/scripts/read_merger.pl
+++ b/scripts/read_merger.pl
@@ -131,6 +131,8 @@ close $fh2;
     elsif ($fastq_input) {
       if ($buffers{$fh} =~ /^@(\S+)/) {
         $id = $1;
+        # remove _1 or .1 from read IDs
+        $id =~ s/[_.][12]//g;
       }
       else {
         if ($buffers{$fh} =~ /^$/) {


### PR DESCRIPTION
Kept running into mismatched mate pair names error because PE reads are simulated r1.1, r1.2, r2.1, r2.2, etc. 
