### PR TITLE
Set default shrink block offset

### DIFF
--- a/scripts/kraken-build
+++ b/scripts/kraken-build
@@ -39,6 +39,7 @@ $ENV{"PATH"} = "$KRAKEN_DIR:$ENV{PATH}";
 my $DEF_MINIMIZER_LEN = 15;
 my $DEF_KMER_LEN = 31;
 my $DEF_THREAD_CT = 1;
+my $DEF_SHRINK_BLOCK_OFFSET = 1;
 
 my @VALID_LIBRARY_TYPES = qw/bacteria plasmids viruses human/;
 
@@ -68,6 +69,7 @@ my (
 $threads = $DEF_THREAD_CT;
 $minimizer_len = $DEF_MINIMIZER_LEN;
 $kmer_len = $DEF_KMER_LEN;
+$shrink_block_offset = $DEF_SHRINK_BLOCK_OFFSET;
 $work_on_disk = "";
 $hash_size = "";
 $max_db_size = "";
@@ -232,7 +234,7 @@ Options:
                              (build task only)
   --shrink-block-offset NUM  When shrinking, select the k-mer that is NUM
                              positions from the end of a block of k-mers
-                             (default: 1)
+                             (def: $DEF_SHRINK_BLOCK_OFFSET)
   --work-on-disk             Perform most operations on disk rather than in
                              RAM (will slow down build in most cases)
 EOF


### PR DESCRIPTION
Currently theres no shrink block offset default so you have to provide the parameter each time, this just sets the default.