### PR TITLE
Skip empty FASTA sequences, and allow to force taxids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/install/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,6 @@
+*.o
+/db_sort
+/classify
+/db_shrink
+/set_lcas
+/make_seqid_to_taxid_map

--- a/src/krakenutil.cpp
+++ b/src/krakenutil.cpp
@@ -53,11 +53,14 @@ namespace kraken {
     if (a == 0 || b == 0)
       return a ? a : b;
 
+    // create a path from a to the root
     set<uint32_t> a_path;
     while (a > 0) {
       a_path.insert(a);
       a = parent_map[a];
     }
+
+    // search for b in the path from a to the root
     while (b > 0) {
       if (a_path.count(b) > 0)
         return b;

--- a/src/seqreader.cpp
+++ b/src/seqreader.cpp
@@ -72,9 +72,7 @@ namespace kraken {
     dna.seq = seq_ss.str();
 
     if (dna.seq.empty()) {
-      warnx("malformed fasta file - zero-length record (%s)", dna.id.c_str());
-      valid = false;
-      return dna;
+      valid = true; // set_lcas handles empty sequences
     }
 
     return dna;

--- a/src/set_lcas.cpp
+++ b/src/set_lcas.cpp
@@ -109,11 +109,19 @@ void process_single_file() {
   FastaReader reader(Multi_fasta_filename);
   DNASequence dna;
   uint32_t seqs_processed = 0;
+  uint32_t seqs_skipped = 0;
+  uint32_t seqs_no_taxid = 0;
 
   while (reader.is_valid()) {
     dna = reader.next_sequence();
     if (! reader.is_valid())
       break;
+
+    if ( dna.seq.empty() ) {
+      ++seq_skipped;
+      continue;
+    }
+
     uint32_t taxid = ID_to_taxon_map[dna.id];
     if (taxid) {
       #pragma omp parallel for schedule(dynamic)


### PR DESCRIPTION
This pull request includes two changes:
 - When observing a empty sequence, the program would exit in previous version. This is fixed. Additionally the number of empty sequences, and the number of sequences without valid taxonomy mapping, are counted and reported at the end.

- Added the option -T to force set_lcas to set the taxid of the sequence as the taxid of its kmers - instead of the LCA. This proves very useful for re-setting the taxids of contaminant sequences after the database build.