### PR TITLE
Allow kraken-report to work when 0 reads have been classified…

### DIFF
--- a/scripts/kraken-report
+++ b/scripts/kraken-report
@@ -91,8 +91,13 @@ for (keys %name_map) {
   $clade_counts{$_} ||= 0;
 }
 
+my $unclassified_percent = 1;
+if ($seq_count) {
+  $unclassified_percent = $clade_counts{0} * 100 / $seq_count;
+}
+
 printf "%6.2f\t%d\t%d\t%s\t%d\t%s%s\n",
-  $clade_counts{0} * 100 / $seq_count,
+  $unclassified_percent,
   $clade_counts{0}, $taxo_counts{0}, "U",
   0, "", "unclassified";
 dfs_report(1, 0);

--- a/scripts/kraken-report
+++ b/scripts/kraken-report
@@ -91,7 +91,7 @@ for (keys %name_map) {
   $clade_counts{$_} ||= 0;
 }
 
-my $unclassified_percent = 1;
+my $unclassified_percent = 100;
 if ($seq_count) {
   $unclassified_percent = $clade_counts{0} * 100 / $seq_count;
 }


### PR DESCRIPTION
… and `--only-classified-output` had been specified. Will report 100% of reads as unclassified.

Test input data is an empty file.