### PR TITLE
Accession compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ in the `docs/` directory (`MANUAL.html` and `MANUAL.markdown`).
 
 [Kraken webpage]:   http://ccb.jhu.edu/software/kraken/
 [Kraken manual]:    http://ccb.jhu.edu/software/kraken/MANUAL.html
+
+Changelog accession
+-------------------
+* Made the download function compatible with NCBI accession numbers
+* No longer unpack fasta files on disk, use zcat instead
+* Added support for all databases listed at ftp.ncbi.nlm.nih.gov/genomes/refseq/
+* Added support for Human
+* Removed support for plasmids
+* Use rsync instead of wget for all downloads
+* Removed the taxon-to-seqid mapping step completely
+* Extract the taxon information directly from assembly\_summary.txt

--- a/scripts/build_kraken_db.sh
+++ b/scripts/build_kraken_db.sh
@@ -154,6 +154,10 @@ else
   echo "K-mer set sorted. [$(report_time_elapsed $start_time1)]"
 fi
 
+echo -n "Concatenating seqid2taxid.map files (step 4 of 6)..."
+cat library/*/seqid2taxid.map > seqid2taxid.map
+echo " complete."
+
 if [ -e "lca.complete" ]
 then
   echo "Skipping step 6, LCAs already set."

--- a/scripts/build_kraken_db.sh
+++ b/scripts/build_kraken_db.sh
@@ -154,33 +154,6 @@ else
   echo "K-mer set sorted. [$(report_time_elapsed $start_time1)]"
 fi
 
-if [ -e "gi2seqid.map" ]
-then
-  echo "Skipping step 4, GI number to seqID map already complete."
-else
-  echo "Creating GI number to seqID map (step 4 of 6)..."
-  start_time1=$(date "+%s.%N")
-  find library/ '(' -name '*.fna' -o -name '*.fa' -o -name '*.ffn' ')' -print0 | \
-    xargs -0 cat | report_gi_numbers.pl > gi2seqid.map.tmp
-  mv gi2seqid.map.tmp gi2seqid.map
-
-  echo "GI number to seqID map created. [$(report_time_elapsed $start_time1)]"
-fi
-
-if [ -e "seqid2taxid.map" ]
-then
-  echo "Skipping step 5, seqID to taxID map already complete."
-else
-  echo "Creating seqID to taxID map (step 5 of 6)..."
-  start_time1=$(date "+%s.%N")
-  make_seqid_to_taxid_map taxonomy/gi_taxid_nucl.dmp gi2seqid.map \
-    > seqid2taxid.map.tmp
-  mv seqid2taxid.map.tmp seqid2taxid.map
-  line_ct=$(wc -l seqid2taxid.map | awk '{print $1}')
-
-  echo "$line_ct sequences mapped to taxa. [$(report_time_elapsed $start_time1)]"
-fi
-
 if [ -e "lca.complete" ]
 then
   echo "Skipping step 6, LCAs already set."

--- a/scripts/build_kraken_db.sh
+++ b/scripts/build_kraken_db.sh
@@ -72,12 +72,12 @@ else
   # Estimate hash size as 1.15 * chars in library FASTA files
   if [ -z "$KRAKEN_HASH_SIZE" ]
   then
-    KRAKEN_HASH_SIZE=$(find library/ '(' -name '*.fna' -o -name '*.fa' -o -name '*.ffn' ')' -printf '%s\n' | perl -nle '$sum += $_; END {print int(1.15 * $sum)}')
+    KRAKEN_HASH_SIZE=$(find library/ '(' -name '*.fna.gz' ')' -printf '%s\n' | perl -nle '$sum += $_; END {print int(1.15 * $sum)}')
     echo "Hash size not specified, using '$KRAKEN_HASH_SIZE'"
   fi
 
-  find library/ '(' -name '*.fna' -o -name '*.fa' -o -name '*.ffn' ')' -print0 | \
-    xargs -0 cat | \
+  find library/ '(' -name '*.fna.gz' ')' -print0 | \
+    xargs -0 zcat | \
     jellyfish count -m $KRAKEN_KMER_LEN -s $KRAKEN_HASH_SIZE -C -t $KRAKEN_THREAD_CT \
       -o database /dev/fd/0
 
@@ -160,8 +160,8 @@ then
 else
   echo "Setting LCAs in database (step 6 of 6)..."
   start_time1=$(date "+%s.%N")
-  find library/ '(' -name '*.fna' -o -name '*.fa' -o -name '*.ffn' ')' -print0 | \
-    xargs -0 cat | \
+  find library/ '(' -name '*.fna.gz' ')' -print0 | \
+    xargs -0 zcat | \
     set_lcas $MEMFLAG -x -d database.kdb -i database.idx \
     -n taxonomy/nodes.dmp -t $KRAKEN_THREAD_CT -m seqid2taxid.map -F /dev/fd/0
   touch "lca.complete"

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -96,7 +96,7 @@ case "$1" in
   *)
     mkdir -p $LIBRARY_DIR/$1
     cd $LIBRARY_DIR/$1
-    wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/$1/assembly_summary.txt
+    $RSYNC ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/$1/assembly_summary.txt
     #### DEBUG START ####
     echo "WARNING: DEBUG ENABLED, DOWNLOADING ONLY 100 SAMPLES PER LIBRARY"
     head -n 100 assembly_summary.txt > t

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -18,11 +18,13 @@
 # along with Kraken.  If not, see <http://www.gnu.org/licenses/>.
 
 # Download specific genomic libraries for use with Kraken.
-# Supported choices are:
-#   bacteria - NCBI RefSeq complete bacterial/archaeal genomes
-#   plasmids - NCBI RefSeq plasmid sequences
-#   viruses - NCBI RefSeq complete viral DNA and RNA genomes
+# Supported choices are the folder (NOT LINKS) here:
+# ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/
+# and also:
 #   human - NCBI RefSeq GRCh38 human reference genome
+
+# Please note: This script does not check if the specified library is valid
+# This is left for the kraken-build script
 
 set -u  # Protect against uninitialized vars.
 set -e  # Stop on error
@@ -34,7 +36,8 @@ FTP_SERVER="ftp://$NCBI_SERVER"
 RSYNC_SERVER="rsync://$NCBI_SERVER"
 SEQ2TAXID="seqid2taxid.map"
 THIS_DIR=$PWD
-RSYNC="rsync --progress -ai --no-relative"
+
+RSYNC="rsync --progress -ai --no-relative --delete --force"
 
 # Just for the pretty printing of rsync progress
 function sameline {
@@ -43,6 +46,7 @@ function sameline {
     done
     echo -e "\r"
 }
+
 function download {
   # Parse samples into a file that rsync can use
   echo -n "Preparing download list..."
@@ -63,82 +67,37 @@ function seqid2taxid {
 }
 
 case "$1" in
-  "bacteria")
-    mkdir -p $LIBRARY_DIR/Bacteria
-    cd $LIBRARY_DIR/Bacteria
-    if [ ! -e "lib.complete" ]
-    then
-      # Get the summary file
-      wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt
-      download
-      seqid2taxid
-      touch "lib.complete"
-    else
-      echo "Skipping download of bacterial genomes, already downloaded here."
-    fi
-    ;;
-  "plasmids")
-    echo "ERROR: plasmids are depricated"
-    exit 1
-    mkdir -p $LIBRARY_DIR/Plasmids
-    cd $LIBRARY_DIR/Plasmids
-    if [ ! -e "lib.complete" ]
-    then
-      rm -f plasmids.all.fna.tar.gz
-      wget $FTP_SERVER/genomes/Plasmids/plasmids.all.fna.tar.gz
-      echo -n "Unpacking..."
-      tar zxf plasmids.all.fna.tar.gz
-      rm plasmids.all.fna.tar.gz
-      echo " complete."
-      touch "lib.complete"
-    else
-      echo "Skipping download of plasmids, already downloaded here."
-    fi
-    ;;
-  "viruses")
-    mkdir -p $LIBRARY_DIR/Viruses
-    cd $LIBRARY_DIR/Viruses
-    if [ ! -e "lib.complete" ]
-    then
-      # Get the summary file
-      wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/viral/assembly_summary.txt
-      download
-      seqid2taxid
-      touch "lib.complete"
-    else
-      echo "Skipping download of viral genomes, already downloaded here."
-    fi
-    ;;
   "human")
-    mkdir -p $LIBRARY_DIR/Human
-    cd $LIBRARY_DIR/Human
-    if [ ! -e "lib.complete" ]
-    then
-      # get list of CHR_* directories
-      echo "Downloading human sequences..."
-      $RSYNC rsync://ftp.ncbi.nlm.nih.gov/genomes/Homo_sapiens/CHR_*/hs_ref_GRCh38.p7_*.fa.gz .
-      echo " complete."
-      # We know all sequences are human, so we can cheat and assigne the taxid
-      # here directly
-      human_taxid=9606
-      echo -n "Mapping seqid to taxid..."
-      for file in hs_ref_GRCh38.p7_*.fa.gz; do
-        zcat $file | grep '^>' |
-          while read header; do
-            header=`echo $header | cut -d ' ' -f 1`
-            echo -e "${header:1}\t$human_taxid" >> ../../$SEQ2TAXID
-          done
-      done
+    # Humans are a special case
+    mkdir -p $LIBRARY_DIR/human
+    cd $LIBRARY_DIR/human
+    echo "Downloading human sequences..."
+    $RSYNC rsync://ftp.ncbi.nlm.nih.gov/genomes/Homo_sapiens/CHR_*/hs_ref_GRCh38.p7_*.fa.gz .
+    echo " complete."
 
-      echo " complete."
+    # We know all sequences are human, so we can cheat and 
+    # assign the taxid here directly
+    human_taxid=9606
+    echo -n "Mapping seqid to taxid..."
+    for file in hs_ref_GRCh38.p7_*.fa.gz; do
+      zcat $file | grep '^>' |
+        while read header; do
+          header=`echo $header | cut -d ' ' -f 1`
+          echo -e "${header:1}\t$human_taxid" >> ../../$SEQ2TAXID
+        done
+    done
 
-      touch "lib.complete"
-    else
-      echo "Skipping download of human genome, already downloaded here."
-    fi
+    echo " complete."
     ;;
   *)
-    echo "Unsupported library.  Valid options are: "
-    echo "  bacteria plasmids virus human"
+    mkdir -p $LIBRARY_DIR/$1
+    cd $LIBRARY_DIR/$1
+    wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/$1/assembly_summary.txt
+    #### DEBUG START ####
+    head -n 1000 assembly_summary.txt > t
+    mv t assembly_summary
+    #### DEBUG END ####
+    download
+    seqid2taxid
     ;;
 esac

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -34,6 +34,13 @@ RSYNC_SERVER="rsync://$NCBI_SERVER"
 SEQ2TAXID="seqid2taxid.map"
 THIS_DIR=$PWD
 
+# Just for the pretty printing of rsync progress
+function sameline {
+    while read line; do
+        echo -ne "$line\r"
+    done
+    echo -e "\r"
+}
 function download {
   # Parse samples into a file that rsync can use
   echo -n "Preparing download list..."
@@ -41,9 +48,9 @@ function download {
   echo " complete."
 
   # Download the files
-  echo -n "Downloading `cat rsync_listing.txt|wc -l` files..."
-  rsync -vai --no-relative --files-from=rsync_listing.txt ftp.ncbi.nlm.nih.gov::genomes .
-  echo " complete."
+  echo "Downloading `cat rsync_listing.txt|wc -l` files..."
+  rsync --progress -ai --no-relative --files-from=rsync_listing.txt ftp.ncbi.nlm.nih.gov::genomes . | sameline
+  echo "Downloading `cat rsync_listing.txt|wc -l` files... complete."
 }
 
 function seqid2taxid {

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -62,7 +62,7 @@ function download {
 function seqid2taxid {
   # Map the headers to taxid
   echo -n "Mapping seqid to taxid..."
-  make_seqid2tax_map.sh assembly_summary.txt . ../../$SEQ2TAXID
+  make_seqid2tax_map.sh assembly_summary.txt . $SEQ2TAXID
   echo " complete."
 }
 
@@ -77,13 +77,17 @@ case "$1" in
 
     # We know all sequences are human, so we can cheat and 
     # assign the taxid here directly
+    
+    # Empty the seqid file
+    echo > $SEQ2TAXID
+
     human_taxid=9606
     echo -n "Mapping seqid to taxid..."
     for file in hs_ref_GRCh38.p7_*.fa.gz; do
       zcat $file | grep '^>' |
         while read header; do
           header=`echo $header | cut -d ' ' -f 1`
-          echo -e "${header:1}\t$human_taxid" >> ../../$SEQ2TAXID
+          echo -e "${header:1}\t$human_taxid" >> $SEQ2TAXID
         done
     done
 
@@ -94,8 +98,9 @@ case "$1" in
     cd $LIBRARY_DIR/$1
     wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/$1/assembly_summary.txt
     #### DEBUG START ####
-    head -n 1000 assembly_summary.txt > t
-    mv t assembly_summary
+    echo "WARNING: DEBUG ENABLED, DOWNLOADING ONLY 100 SAMPLES PER LIBRARY"
+    head -n 100 assembly_summary.txt > t
+    mv t assembly_summary.txt
     #### DEBUG END ####
     download
     seqid2taxid

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -42,12 +42,7 @@ function download {
 
   # Download the files
   echo -n "Downloading `cat rsync_listing.txt|wc -l` files..."
-  rsync -q -vai --no-relative --files-from=rsync_listing.txt ftp.ncbi.nlm.nih.gov::genomes .
-  echo " complete."
-
-  # Unpack the files
-  echo -n "Unpacking..."
-  gunzip *_genomic.fna.gz
+  rsync -vai --no-relative --files-from=rsync_listing.txt ftp.ncbi.nlm.nih.gov::genomes .
   echo " complete."
 }
 

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -36,10 +36,12 @@ THIS_DIR=$PWD
 
 function download {
   # Parse samples into a file that rsync can use
+  echo -n "Preparing download list..."
   make_rsync_file.sh assembly_summary.txt rsync_listing.txt
+  echo " complete."
 
   # Download the files
-  echo -n "Downloading..."
+  echo -n "Downloading `cat rsync_listing.txt|wc -l` files..."
   rsync -q -vai --no-relative --files-from=rsync_listing.txt ftp.ncbi.nlm.nih.gov::genomes .
   echo " complete."
 
@@ -97,6 +99,7 @@ case "$1" in
       # Get the summary file
       wget -q ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/viral/assembly_summary.txt
       download
+      seqid2taxid
       touch "lib.complete"
     else
       echo "Skipping download of viral genomes, already downloaded here."

--- a/scripts/download_genomic_library.sh
+++ b/scripts/download_genomic_library.sh
@@ -62,7 +62,7 @@ function download {
 function seqid2taxid {
   # Map the headers to taxid
   echo -n "Mapping seqid to taxid..."
-  make_seqid2tax_map.sh assembly_summary.txt . $SEQ2TAXID
+  make_seqid2tax_map.py assembly_summary.txt . $SEQ2TAXID
   echo " complete."
 }
 

--- a/scripts/download_taxonomy.sh
+++ b/scripts/download_taxonomy.sh
@@ -31,25 +31,11 @@ THIS_DIR=$PWD
 mkdir -p "$TAXONOMY_DIR"
 cd "$TAXONOMY_DIR"
 
-if [ ! -e "gimap.dlflag" ]
-then
-  wget $FTP_SERVER/pub/taxonomy/gi_taxid_nucl.dmp.gz
-  touch gimap.dlflag
-  echo "Downloaded GI to taxon map"
-fi
-
 if [ ! -e "taxdump.dlflag" ]
 then
   wget $FTP_SERVER/pub/taxonomy/taxdump.tar.gz
   touch taxdump.dlflag
   echo "Downloaded taxonomy tree data"
-fi
-
-if [ ! -e "gimap.flag" ]
-then
-  gunzip gi_taxid_nucl.dmp.gz
-  touch gimap.flag
-  echo "Uncompressed GI to taxon map"
 fi
 
 if [ ! -e "taxdump.flag" ]

--- a/scripts/download_taxonomy.sh
+++ b/scripts/download_taxonomy.sh
@@ -28,12 +28,14 @@ NCBI_SERVER="ftp.ncbi.nih.gov"
 FTP_SERVER="ftp://$NCBI_SERVER"
 THIS_DIR=$PWD
 
+RSYNC="rsync --progress -ai --no-relative"
+
 mkdir -p "$TAXONOMY_DIR"
 cd "$TAXONOMY_DIR"
 
 if [ ! -e "taxdump.dlflag" ]
 then
-  wget $FTP_SERVER/pub/taxonomy/taxdump.tar.gz
+  $RSYNC $FTP_SERVER/pub/taxonomy/taxdump.tar.gz
   touch taxdump.dlflag
   echo "Downloaded taxonomy tree data"
 fi

--- a/scripts/kraken-build
+++ b/scripts/kraken-build
@@ -40,7 +40,7 @@ my $DEF_MINIMIZER_LEN = 15;
 my $DEF_KMER_LEN = 31;
 my $DEF_THREAD_CT = 1;
 
-my @VALID_LIBRARY_TYPES = qw/bacteria plasmids viruses human/;
+my @VALID_LIBRARY_TYPES = qw/archaea bacteria fungi invertebrate plant protozoa vertebrate_mammalian vertebrate_other viral human/;
 
 # Option/task option variables
 my (
@@ -199,8 +199,10 @@ Usage: $PROG [task option] [options]
 Task options (exactly one must be selected):
   --download-taxonomy        Download NCBI taxonomic information
   --download-library TYPE    Download partial library
-                             (TYPE = one of "bacteria", "plasmids", 
-                             "viruses", "human")
+                             (TYPE = one of "archaea", "bacteria", "fungi",
+                             "invertebrate", "plant", "protozoa",
+                             "vertebrate_mammalian", "vertebrate_other",
+                             "viral", "human")
   --add-to-library FILE      Add FILE to library
   --build                    Create DB from library
                              (requires taxonomy d/l'ed and at least one file

--- a/scripts/make_rsync_file.sh
+++ b/scripts/make_rsync_file.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+#TODO: protect agains unassigned variables
+EXTENSION="_genomic.fna.gz"
+
+if [ $# -ne 2 ]; then
+    echo "Usage: make_rsync_file.sh assembly_summary.txt rsync_listing.txt"
+    exit 1
+fi
+assembly_summary=$1
+rsync_listing=$2
+
+rm -f $rsync_listing
+
+while read line; do
+    case "$line" in \#*)
+        continue;;
+      *)
+        ftp_path=`echo -e "$line" | cut -f 20`
+        sample=`basename $ftp_path`
+        rsync_path=${ftp_path#ftp://ftp.ncbi.nlm.nih.gov/genomes}
+        rsync_path=$rsync_path/$sample$EXTENSION
+        echo "$rsync_path" >> $rsync_listing
+        
+    esac
+done < $assembly_summary

--- a/scripts/make_seqid2tax_map.py
+++ b/scripts/make_seqid2tax_map.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import gzip
+
+extension='_genomic.fna.gz'
+if len(sys.argv) < 4:
+    print("Usage: {} assembly_summary.txt folder seqid2tax.map".format(sys.argv[0]))
+    exit(1)
+
+assembly=sys.argv[1]
+folder=sys.argv[2]
+mapping=sys.argv[3]
+
+with open(assembly,'r') as fin:
+    with open(mapping,'w') as out:
+        for line in fin:
+            if line.startswith('#'):
+                continue
+            spline=line.split('\t')
+            taxid=spline[5]
+            ftppath=spline[19]
+            filename=os.path.basename(ftppath)
+            fasta=os.path.join(folder,filename)+extension
+
+            with gzip.open(fasta,'rt') as fas:
+                for line in fas:
+                    if line.startswith('>'):    
+                        print(line.split()[0][1:],taxid,sep='\t',file=out)

--- a/scripts/make_seqid2tax_map.sh
+++ b/scripts/make_seqid2tax_map.sh
@@ -25,7 +25,8 @@ while read line; do
         # Read all headers
         grep '^>' < $fasta |
         while read header; do
-            echo -e "${header#>}\t$taxid" >> seqid2tax
+            header=`echo $header | cut -d ' ' -f 1`
+            echo -e "${header:1}\t$taxid" >> $seqid2tax
         done 
         exit
     esac

--- a/scripts/make_seqid2tax_map.sh
+++ b/scripts/make_seqid2tax_map.sh
@@ -13,6 +13,10 @@ fi
 assembly_summary=$1
 folder=$2
 seqid2tax=$3
+
+# Empty the seqid2taxid file
+echo > $seqid2tax
+
 while read line; do
     case "$line" in \#*)
         continue;;

--- a/scripts/make_seqid2tax_map.sh
+++ b/scripts/make_seqid2tax_map.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+#TODO: protect agains unassigned variables
+EXTENSION="_genomic.fna.gz"
+
+if [ $# -ne 3 ];then
+    echo "Usage: make_seqid2taxid_map.sh assembly_summary.txt folder seqid2tax.map"
+    exit 1
+fi
+
+assembly_summary=$1
+folder=$2
+seqid2tax=$3
+while read line; do
+    case "$line" in \#*)
+        continue;;
+      *)
+        ftp_path=`echo -e "$line" | cut -f 20`
+        taxid=`echo -e "$line" | cut -f 6`
+        sample=`basename $ftp_path`
+        fasta=$folder/$sample${EXTENSION%.gz}
+
+        # Read all headers
+        grep '^>' < $fasta |
+        while read header; do
+            echo -e "${header#>}\t$taxid" >> seqid2tax
+        done 
+        exit
+    esac
+done < $assembly_summary

--- a/scripts/make_seqid2tax_map.sh
+++ b/scripts/make_seqid2tax_map.sh
@@ -20,10 +20,10 @@ while read line; do
         ftp_path=`echo -e "$line" | cut -f 20`
         taxid=`echo -e "$line" | cut -f 6`
         sample=`basename $ftp_path`
-        fasta=$folder/$sample${EXTENSION%.gz}
+        fasta=$folder/$sample${EXTENSION}
 
         # Read all headers
-        grep '^>' < $fasta |
+        zcat $fasta | grep '^>' |
         while read header; do
             header=`echo $header | cut -d ' ' -f 1`
             echo -e "${header:1}\t$taxid" >> $seqid2tax

--- a/scripts/make_seqid2tax_map.sh
+++ b/scripts/make_seqid2tax_map.sh
@@ -28,6 +28,5 @@ while read line; do
             header=`echo $header | cut -d ' ' -f 1`
             echo -e "${header:1}\t$taxid" >> $seqid2tax
         done 
-        exit
     esac
 done < $assembly_summary


### PR DESCRIPTION
I've made various improvements to the download options of kraken:

+Changelog accession
+-------------------
+* Made the download function compatible with NCBI accession numbers
+* No longer unpack fasta files on disk, use zcat instead
+* Added support for all databases listed at ftp.ncbi.nlm.nih.gov/genomes/refseq/
+* Added support for Human
+* Removed support for plasmids
+* Use rsync instead of wget for all downloads
+* Removed the taxon-to-seqid mapping step completely
+* Extract the taxon information directly from assembly\_summary.txt