### PR TITLE
Easy un-pair

### DIFF
--- a/scripts/kraken
+++ b/scripts/kraken
@@ -139,7 +139,7 @@ push @flags, "-t", $threads if $threads > 1;
 push @flags, "-n", $taxonomy if defined $taxonomy;
 push @flags, "-q" if $quick;
 push @flags, "-m", $min_hits if $min_hits > 1;
-push @flags, "-f" if $fastq_input && ! $paired;  # merger always outputs FASTA
+push @flags, "-f" if $fastq_input;
 push @flags, "-U", $unclassified_out if defined $unclassified_out;
 push @flags, "-C", $classified_out if defined $classified_out;
 push @flags, "-o", $outfile if defined $outfile;

--- a/scripts/kraken
+++ b/scripts/kraken
@@ -168,6 +168,7 @@ if ($paired) {
   push @merge_flags, "--gz" if $gunzip;
   push @merge_flags, "--bz2" if $bunzip2;
   push @merge_flags, "--check-names" if $check_names;
+  push @merge_flags, "--output-format", $output_format if defined $output_format;
   @pipe_argv = ("read_merger.pl", @merge_flags, @ARGV);
 }
 elsif ($compressed) {
@@ -233,6 +234,8 @@ Options:
                           Print unclassified sequences to filename
   --classified-out FILENAME
                           Print classified sequences to filename
+  --out-fmt FORMAT        Format for [un]classified sequence output. supported 
+                          options are: {legacy, paired, interleaved}
   --output FILENAME       Print output to filename (default: stdout); "-" will
                           suppress normal output
   --only-classified-output

--- a/scripts/kraken
+++ b/scripts/kraken
@@ -54,7 +54,9 @@ my $paired = 0;
 my $check_names = 0;
 my $only_classified_output = 0;
 my $unclassified_out;
+my $unclassified_out_prefix;
 my $classified_out;
+my $classified_out_prefix;
 my $outfile;
 
 GetOptions(
@@ -67,7 +69,9 @@ GetOptions(
   "quick" => \$quick,
   "min-hits=i" => \$min_hits,
   "unclassified-out=s" => \$unclassified_out,
+  "unclassified-out-prefix=s" => \$unclassified_out_prefix,
   "classified-out=s" => \$classified_out,
+  "classified-out-prefix=s" => \$classified_out_prefix,
   "output=s" => \$outfile,
   "preload" => \$preload,
   "paired" => \$paired,
@@ -141,10 +145,13 @@ push @flags, "-q" if $quick;
 push @flags, "-m", $min_hits if $min_hits > 1;
 push @flags, "-f" if $fastq_input;
 push @flags, "-U", $unclassified_out if defined $unclassified_out;
+push @flags, "-r", $unclassified_out_prefix if defined $unclassified_out_prefix;
 push @flags, "-C", $classified_out if defined $classified_out;
+push @flags, "-p", $classified_out_prefix if defined $classified_out_prefix;
 push @flags, "-o", $outfile if defined $outfile;
 push @flags, "-c", if $only_classified_output;
 push @flags, "-M" if $preload;
+push @flags, "-P", if $paired;
 
 # handle piping for decompression/merging
 my @pipe_argv;

--- a/scripts/kraken
+++ b/scripts/kraken
@@ -45,6 +45,7 @@ my $quick = 0;
 my $min_hits = 1;
 my $fasta_input = 0;
 my $fastq_input = 0;
+my $fastq_output = 0;
 my $db_prefix;
 my $threads;
 my $preload = 0;
@@ -57,6 +58,7 @@ my $unclassified_out;
 my $unclassified_out_prefix;
 my $classified_out;
 my $classified_out_prefix;
+my $output_format = "legacy";
 my $outfile;
 
 GetOptions(
@@ -66,12 +68,14 @@ GetOptions(
   "threads=i" => \$threads,
   "fasta-input" => \$fasta_input,
   "fastq-input" => \$fastq_input,
+  "fastq-output" => \$fastq_output,
   "quick" => \$quick,
   "min-hits=i" => \$min_hits,
   "unclassified-out=s" => \$unclassified_out,
   "unclassified-out-prefix=s" => \$unclassified_out_prefix,
   "classified-out=s" => \$classified_out,
   "classified-out-prefix=s" => \$classified_out_prefix,
+  "out-fmt=s" => \$output_format,
   "output=s" => \$outfile,
   "preload" => \$preload,
   "paired" => \$paired,
@@ -141,16 +145,18 @@ push @flags, "-d", $kdb_file;
 push @flags, "-i", $idx_file;
 push @flags, "-t", $threads if $threads > 1;
 push @flags, "-n", $taxonomy if defined $taxonomy;
-push @flags, "-q" if $quick;
+push @flags, "-q", if $quick;
 push @flags, "-m", $min_hits if $min_hits > 1;
-push @flags, "-f" if $fastq_input;
+push @flags, "-f", if $fastq_input;
+push @flags, "-F", if $fastq_output;
 push @flags, "-U", $unclassified_out if defined $unclassified_out;
 push @flags, "-r", $unclassified_out_prefix if defined $unclassified_out_prefix;
 push @flags, "-C", $classified_out if defined $classified_out;
 push @flags, "-p", $classified_out_prefix if defined $classified_out_prefix;
+push @flags, "-O", $output_format if defined $output_format;
 push @flags, "-o", $outfile if defined $outfile;
 push @flags, "-c", if $only_classified_output;
-push @flags, "-M" if $preload;
+push @flags, "-M", if $preload;
 push @flags, "-P", if $paired;
 
 # handle piping for decompression/merging
@@ -217,6 +223,7 @@ Options:
   --threads NUM           Number of threads (default: $def_thread_ct)
   --fasta-input           Input is FASTA format
   --fastq-input           Input is FASTQ format
+  --fastq-output          Output in FASTQ format
   --gzip-compressed       Input is gzip compressed
   --bzip2-compressed      Input is bzip2 compressed
   --quick                 Quick operation (use first hit or hits)

--- a/scripts/kraken
+++ b/scripts/kraken
@@ -55,9 +55,7 @@ my $paired = 0;
 my $check_names = 0;
 my $only_classified_output = 0;
 my $unclassified_out;
-my $unclassified_out_prefix;
 my $classified_out;
-my $classified_out_prefix;
 my $output_format = "legacy";
 my $outfile;
 
@@ -72,9 +70,7 @@ GetOptions(
   "quick" => \$quick,
   "min-hits=i" => \$min_hits,
   "unclassified-out=s" => \$unclassified_out,
-  "unclassified-out-prefix=s" => \$unclassified_out_prefix,
   "classified-out=s" => \$classified_out,
-  "classified-out-prefix=s" => \$classified_out_prefix,
   "out-fmt=s" => \$output_format,
   "output=s" => \$outfile,
   "preload" => \$preload,
@@ -150,9 +146,7 @@ push @flags, "-m", $min_hits if $min_hits > 1;
 push @flags, "-f", if $fastq_input;
 push @flags, "-F", if $fastq_output;
 push @flags, "-U", $unclassified_out if defined $unclassified_out;
-push @flags, "-r", $unclassified_out_prefix if defined $unclassified_out_prefix;
 push @flags, "-C", $classified_out if defined $classified_out;
-push @flags, "-p", $classified_out_prefix if defined $classified_out_prefix;
 push @flags, "-O", $output_format if defined $output_format;
 push @flags, "-o", $outfile if defined $outfile;
 push @flags, "-c", if $only_classified_output;

--- a/scripts/read_merger.pl
+++ b/scripts/read_merger.pl
@@ -160,5 +160,5 @@ close $fh2;
 sub print_merged_sequence {
   my ($seq1, $seq2) = @_;
   print ">" . $seq1->{id} . "\n";
-  print $seq1->{seq} . "N" . $seq2->{seq} . "\n";
+  print $seq1->{seq} . "|" . $seq2->{seq} . "\n";
 }

--- a/scripts/read_merger.pl
+++ b/scripts/read_merger.pl
@@ -90,8 +90,12 @@ while (defined($seq1 = read_sequence($fh1))) {
   if (! defined $seq2) {
     die "$PROG: mismatched sequence counts\n";
   }
-  if ($check_names && $seq1->{id} ne $seq2->{id}) {
-    die "$PROG: mismatched mate pair names ('$seq1->{id}' & '$seq2->{id}')\n";
+  if ($check_names) {
+    my $comparison_id1 = $seq1->{id} =~ /(\S+)/; # Only check up until first whitespace character
+    my $comparison_id2 = $seq2->{id} =~ /(\S+)/;
+    if ($comparison_id1 ne $comparison_id2) {
+        die "$PROG: mismatched mate pair names ('$seq1->{id}' & '$seq2->{id}')\n";
+    }
   }
   if ($fastq_input) {
       print_merged_sequence_fastq($seq1, $seq2);
@@ -139,7 +143,7 @@ close $fh2;
       }
     }
     elsif ($fastq_input) {
-      if ($buffers{$fh} =~ /^@(\S+)/) {
+      if ($buffers{$fh} =~ /^@(\S+\s\S+)/) {  # Allow one whitespace character in fastq header
         $id = $1;
       }
       else {
@@ -158,7 +162,6 @@ close $fh2;
       die "$PROG: I have no idea what kind of input I'm reading!!!\n";
     }
 
-    $id =~ s/[\/_.][12]$//;  # strip /1 (or .1, _1) or /2 to help comparison
     return { id => $id, seq => $seq, qual => $qual };
   }
 }

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -356,13 +356,54 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 	(*oss_ptr2) << ">" << header2 << endl
 		    << seq2 << endl;
       }
-      else if (Fastq_output && ! (Output_format == "paired")) {
+      else if (Fastq_output && Output_format == "legacy") {
 	(*oss_ptr) << "@" << dna.header_line << endl
 		   << dna.seq << endl
 		   << "+" << endl
 		   << dna.quals << endl;
       }
-      else {
+      else if (Fastq_output && Output_format == "interleaved") {
+	string delimiter = "|";
+	size_t pos = 0;
+	pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, pos);
+	string header2 = dna.header_line.substr(pos + delimiter.length());
+	pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, pos);
+	string seq2 = dna.seq.substr(pos + delimiter.length());
+	pos = dna.quals.find(delimiter);
+	string quals1 = dna.quals.substr(0, pos);
+	string quals2 = dna.quals.substr(pos + delimiter.length());
+	(*oss_ptr) << "@" << header1 << endl
+		   << seq1 << endl
+		   << "+" << endl
+		   << quals1 << endl;
+	(*oss_ptr) << "@" << header2 << endl
+		   << seq2 << endl
+		   << "+" << endl
+		   << quals2 << endl;
+      }
+      else if (! Fastq_output && Output_format == "interleaved") {
+	string delimiter = "|";
+	size_t pos = 0;
+	pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, pos);
+	string header2 = dna.header_line.substr(pos + delimiter.length());
+	pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, pos);
+	string seq2 = dna.seq.substr(pos + delimiter.length());
+	(*oss_ptr) << ">" << header1 << endl
+		   << seq1 << endl;
+	(*oss_ptr) << ">" << header2 << endl
+		   << seq2 << endl;
+      }
+      else if (Fastq_output && Output_format == "legacy") {
+	(*oss_ptr) << "@" << dna.header_line << endl
+		   << dna.seq << endl
+		   << "+" << endl
+		   << dna.quals << endl;
+      }
+      else if (! Fastq_output && Output_format == "legacy") {
 	(*oss_ptr) << ">" << dna.header_line << endl
 		   << dna.seq << endl;
       }
@@ -537,6 +578,14 @@ void parse_command_line(int argc, char **argv) {
   }
   if (Output_format == "paired" && (Classified_output_file == "-" || Unclassified_output_file == "-")) {
     cerr << "Can't send paired output to stdout" << endl;
+    usage();
+  }
+  if ((Output_format == "paired" || Output_format == "interleaved") && ! Paired_input) {
+    cerr << "Output format " << Output_format << " requires paired input" << endl;
+    usage();
+  }
+  if (Output_format == "legacy" && Fastq_output) {
+    cerr << "FASTQ output not supported for legacy ('N' delimited) output format. Use '--out-fmt paired'" << endl;
     usage();
   }
   if (Fastq_output && ! Fastq_input) {

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -480,7 +480,7 @@ void parse_command_line(int argc, char **argv) {
 
   if (argc > 1 && strcmp(argv[1], "-h") == 0)
     usage(0);
-  while ((opt = getopt(argc, argv, "d:i:t:u:n:m:o:p:r:qfFPcC:O:U:M")) != -1) {
+  while ((opt = getopt(argc, argv, "d:i:t:u:n:m:o:qfFPcC:O:U:M")) != -1) {
     switch (opt) {
       case 'd' :
         DB_filename = optarg;

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -397,12 +397,6 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 	(*oss_ptr) << ">" << header2 << endl
 		   << seq2 << endl;
       }
-      else if (Fastq_output && Output_format == "legacy") {
-	(*oss_ptr) << "@" << dna.header_line << endl
-		   << dna.seq << endl
-		   << "+" << endl
-		   << dna.quals << endl;
-      }
       else if (! Fastq_output && Output_format == "legacy") {
 	(*oss_ptr) << ">" << dna.header_line << endl
 		   << dna.seq << endl;

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -321,8 +321,8 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
     }
     bool print = call ? Print_classified : Print_unclassified;
     if (print) {
+      string delimiter = "|";
       if (Fastq_output && Output_format == "paired") {
-	string delimiter = "|";
 	size_t pos = 0;
 	pos = dna.header_line.find(delimiter);
 	string header1 = dna.header_line.substr(0, pos);
@@ -343,7 +343,6 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		    << quals2 << endl;
       }
       else if (! Fastq_output && Output_format == "paired") {
-	string delimiter = "|";
 	size_t pos = 0;
 	pos = dna.header_line.find(delimiter);
 	string header1 = dna.header_line.substr(0, pos);
@@ -363,7 +362,6 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		   << dna.quals << endl;
       }
       else if (Fastq_output && Output_format == "interleaved") {
-	string delimiter = "|";
 	size_t pos = 0;
 	pos = dna.header_line.find(delimiter);
 	string header1 = dna.header_line.substr(0, pos);
@@ -384,7 +382,6 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		   << quals2 << endl;
       }
       else if (! Fastq_output && Output_format == "interleaved") {
-	string delimiter = "|";
 	size_t pos = 0;
 	pos = dna.header_line.find(delimiter);
 	string header1 = dna.header_line.substr(0, pos);

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -323,16 +323,16 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
     if (print) {
       string delimiter = "|";
       if (Fastq_output && Output_format == "paired") {
-	size_t pos = 0;
-	pos = dna.header_line.find(delimiter);
-	string header1 = dna.header_line.substr(0, pos);
-	string header2 = dna.header_line.substr(pos + delimiter.length());
-	pos = dna.seq.find(delimiter);
-	string seq1 = dna.seq.substr(0, pos);
-	string seq2 = dna.seq.substr(pos + delimiter.length());
-	pos = dna.quals.find(delimiter);
-	string quals1 = dna.quals.substr(0, pos);
-	string quals2 = dna.quals.substr(pos + delimiter.length());
+	size_t delimiter_pos = 0;
+	delimiter_pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, delimiter_pos);
+	string header2 = dna.header_line.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, delimiter_pos);
+	string seq2 = dna.seq.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.quals.find(delimiter);
+	string quals1 = dna.quals.substr(0, delimiter_pos);
+	string quals2 = dna.quals.substr(delimiter_pos + delimiter.length());
 	(*oss_ptr) << "@" << header1 << endl
 		   << seq1 << endl
 		   << "+" << endl
@@ -343,13 +343,13 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		    << quals2 << endl;
       }
       else if (! Fastq_output && Output_format == "paired") {
-	size_t pos = 0;
-	pos = dna.header_line.find(delimiter);
-	string header1 = dna.header_line.substr(0, pos);
-	string header2 = dna.header_line.substr(pos + delimiter.length());
-	pos = dna.seq.find(delimiter);
-	string seq1 = dna.seq.substr(0, pos);
-	string seq2 = dna.seq.substr(pos + delimiter.length());
+	size_t delimiter_pos = 0;
+	delimiter_pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, delimiter_pos);
+	string header2 = dna.header_line.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, delimiter_pos);
+	string seq2 = dna.seq.substr(delimiter_pos + delimiter.length());
 	(*oss_ptr) << ">" << header1 << endl
 		   << seq1 << endl;
 	(*oss_ptr2) << ">" << header2 << endl
@@ -362,16 +362,16 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		   << dna.quals << endl;
       }
       else if (Fastq_output && Output_format == "interleaved") {
-	size_t pos = 0;
-	pos = dna.header_line.find(delimiter);
-	string header1 = dna.header_line.substr(0, pos);
-	string header2 = dna.header_line.substr(pos + delimiter.length());
-	pos = dna.seq.find(delimiter);
-	string seq1 = dna.seq.substr(0, pos);
-	string seq2 = dna.seq.substr(pos + delimiter.length());
-	pos = dna.quals.find(delimiter);
-	string quals1 = dna.quals.substr(0, pos);
-	string quals2 = dna.quals.substr(pos + delimiter.length());
+	size_t delimiter_pos = 0;
+	delimiter_pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, delimiter_pos);
+	string header2 = dna.header_line.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, delimiter_pos);
+	string seq2 = dna.seq.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.quals.find(delimiter);
+	string quals1 = dna.quals.substr(0, delimiter_pos);
+	string quals2 = dna.quals.substr(delimiter_pos + delimiter.length());
 	(*oss_ptr) << "@" << header1 << endl
 		   << seq1 << endl
 		   << "+" << endl
@@ -382,13 +382,13 @@ void classify_sequence(DNASequence &dna, ostringstream &koss,
 		   << quals2 << endl;
       }
       else if (! Fastq_output && Output_format == "interleaved") {
-	size_t pos = 0;
-	pos = dna.header_line.find(delimiter);
-	string header1 = dna.header_line.substr(0, pos);
-	string header2 = dna.header_line.substr(pos + delimiter.length());
-	pos = dna.seq.find(delimiter);
-	string seq1 = dna.seq.substr(0, pos);
-	string seq2 = dna.seq.substr(pos + delimiter.length());
+	size_t delimiter_pos = 0;
+	delimiter_pos = dna.header_line.find(delimiter);
+	string header1 = dna.header_line.substr(0, delimiter_pos);
+	string header2 = dna.header_line.substr(delimiter_pos + delimiter.length());
+	delimiter_pos = dna.seq.find(delimiter);
+	string seq1 = dna.seq.substr(0, delimiter_pos);
+	string seq2 = dna.seq.substr(delimiter_pos + delimiter.length());
 	(*oss_ptr) << ">" << header1 << endl
 		   << seq1 << endl;
 	(*oss_ptr) << ">" << header2 << endl


### PR DESCRIPTION
Addresses #84.

I preserved default behavior, so `--out-fmt legacy` is the default. It still outputs `N` as the sequence delimiter.

When `--out-fmt paired` is used, then `--classified-out` and `--unclassified-out` are interpreted as prefixes. 

Default output is fasta, but I've also added a `--fastq-output` flag that will give fastq output. Fastq headers can have one whitespace character, but anything after a second whitespace character would be dropped. `--out-fmt legacy` is incompatible with `--fastq-output`. 

When `--out-fmt paired` is used with `--fastq-output` then the output prefixes are appended with `_R1.fastq` and `_R2.fastq`. Otherwise they're appended with `_R1.fa` and `_R2.fa`.

`--out-fmt interleaved` gives an interleaved file.

I use `|` as a delimiter internally, but they aren't printed in the output in any setting. 

I've done my best to test out all combinations but I'd suggest testing more before merging into `master`.

Forgive my clumsy C++.
