### PR TITLE
Install kraken to $PREFIX/libexec and symlink from $PREFIX/bin

### DIFF
--- a/install_kraken.sh
+++ b/install_kraken.sh
@@ -38,18 +38,23 @@ fi
 # on OS X.
 export KRAKEN_DIR=$(perl -MCwd=abs_path -le 'print abs_path(shift)' "$1")
 
-mkdir -p "$KRAKEN_DIR"
+mkdir -p "$KRAKEN_DIR/libexec"
+mkdir -p "$KRAKEN_DIR/bin"
 make -C src install
 for file in scripts/*
 do
   perl -pl -e 'BEGIN { while (@ARGV) { $_ = shift; ($k,$v) = split /=/, $_, 2; $H{$k} = $v } }'\
            -e 's/#####=(\w+)=#####/$H{$1}/g' \
            "KRAKEN_DIR=$KRAKEN_DIR" "VERSION=$VERSION" \
-           < "$file" > "$KRAKEN_DIR/$(basename $file)"
+           < "$file" > "$KRAKEN_DIR/libexec/$(basename $file)"
   if [ -x "$file" ]
   then
-    chmod +x "$KRAKEN_DIR/$(basename $file)"
+    chmod +x "$KRAKEN_DIR/libexec/$(basename $file)"
   fi
+done
+
+for file in "$KRAKEN_DIR/libexec/kraken" "$KRAKEN_DIR/libexec/kraken-*"; do
+    ln -sf $file "$KRAKEN_DIR/bin"
 done
 
 echo


### PR DESCRIPTION
Only symlink the binaries that users are supposed to call.

This approach (from `homebrew-science`) reduces the number of binaries on `$PATH` 