### PR TITLE
read_merger.pl to support named pipes as inputs

### DIFF
--- a/scripts/read_merger.pl
+++ b/scripts/read_merger.pl
@@ -49,9 +49,9 @@ if (@ARGV != 2) {
 for my $file (@ARGV) {
   if (! -e $file) {
     die "$PROG: $file does not exist\n";
-  } 
-  if (! -f $file) {
-    die "$PROG: $file is not a regular file\n";
+  }
+  if (! -f $file && ! -p $file) {
+     die "$PROG: $file is not a plain file or named pipe\n";
   }
 }
 
@@ -158,7 +158,7 @@ close $fh2;
       else {
 	  $fastq_header_regex = qr/^@(\S+\s\S+)/; # Allow one whitespace character in fastq header
       }
-      if ($buffers{$fh} =~ $fastq_header_regex) {  
+      if ($buffers{$fh} =~ $fastq_header_regex) {
         $id = $1;
       }
       else {


### PR DESCRIPTION
Would you be willing to support named pipes when classifying with Kraken?

I store paired-end reads in BAM and, instead of storing the intermediate FASTQ on disk, stream the paired sequences into Kraken with named pipes. This offers good speedups as I am not writing to the filesystem when using BAM as a source file. Thanks!

Example:

```bash
❯ mkfifo /tmp/fastq{1,2}
❯ picard SamToFastq \
    INPUT=input.bam \
    FASTQ=/tmp/fastq1 \
    SECOND_END_FASTQ=/tmp/fastq2 \
  | kraken \
    --fastq-input \
    --paired \
    --db "${DBNAME}" \
    /tmp/fastq1 \
    /tmp/fastq2 \
    > output.txt
```