### PR TITLE
support for undefined taxa and for percentages of seqlengths

### DIFF
--- a/scripts/kraken-report
+++ b/scripts/kraken-report
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright 2013-2015, Derrick Wood <dwood@cs.jhu.edu>
 #


### PR DESCRIPTION
Hi @DerrickWood , I was having issues with my personal database where I edited my own taxonomy and where I needed to assess contigs instead of reads.  Where I messed up the taxonomy, I created a better warning message and added a category "UNKNOWN" to the report.

Also, instead of proportions of the taxonomy being rated by seq count, I changed it to seq lengths.  This adds more meaning to me in the report and avoids skewing the report from smaller contigs.

Even if my revisions are taken as suggestions, thank you for taking the time to look it over.