### PR TITLE
apply patch from @tillea to remove `gi|` from fasta headers

### DIFF
--- a/scripts/scan_fasta_file.pl
+++ b/scripts/scan_fasta_file.pl
@@ -32,6 +32,8 @@ while (<>) {
   # while (/.../g) needed because non-redundant DBs sometimes have multiple
   #   sequence IDs in the header; extra sequence IDs are prefixed by
   #   '\x01' characters (if downloaded in FASTA format from NCBI FTP directly).
+  s/^>gi\|/>/;
+  s/\| .*//;
   while (/(?:^>|\x01)(\S+)/g) {
     my $seqid = $1;
     my $taxid = krakenlib::check_seqid($seqid);


### PR DESCRIPTION
Fixes #111 

Removes `gi|` prefix from fasta deflines.